### PR TITLE
fix: align gaps configuration and enable fullscreen option

### DIFF
--- a/modules/user/desktop/hyprland/default.nix
+++ b/modules/user/desktop/hyprland/default.nix
@@ -82,8 +82,11 @@ in {
         general = {
           layout = "dwindle";
           resize_on_border = true;
+          no_cursor_warps = true;
+          # gaps_in = 8;
+          # gaps_out = 15;
           gaps_in = 8;
-          gaps_out = 15;
+          gaps_out = 28;
           border_size = 3;
           "col.active_border" = "rgb(EED49F) rgb(EED49F)";
           "col.inactive_border" = "0xff24455b";

--- a/packages/ags/lib/hyprland.ts
+++ b/packages/ags/lib/hyprland.ts
@@ -51,13 +51,15 @@ async function setupHyprland() {
     const wm_gaps = Math.floor(hyprland.gaps.value * spacing.value)
 
     sendBatch([
-        `general:border_size ${width.value}`,
+        `general:border_size ${width}`,
         `general:gaps_out ${wm_gaps}`,
         `general:gaps_in ${Math.floor(wm_gaps / 2)}`,
         `general:col.active_border rgba(${activeBorder()}ff)`,
         `general:col.inactive_border rgba(${hyprland.inactiveBorder.value})`,
-        `decoration:rounding ${radius.value}`,
+        `decoration:rounding ${radius}`,
         `decoration:drop_shadow ${shadows.value ? "yes" : "no"}`,
+        `dwindle:no_gaps_when_only ${hyprland.gapsWhenOnly.value ? 0 : 1}`,
+        `master:no_gaps_when_only ${hyprland.gapsWhenOnly.value ? 0 : 1}`,
     ])
 
     await sendBatch(App.windows.map(({ name }) => `layerrule unset, ${name}`))

--- a/packages/ags/options.ts
+++ b/packages/ags/options.ts
@@ -216,6 +216,7 @@ const options = mkOptions(OPTIONS, {
     hyprland: {
         gaps: opt(2.4),
         inactiveBorder: opt("333333ff"),
+        gapsWhenOnly: opt(true),
     },
 })
 

--- a/packages/ags/widget/settings/layout.ts
+++ b/packages/ags/widget/settings/layout.ts
@@ -16,6 +16,7 @@ const {
     powermenu: pm,
     quicksettings: qs,
     osd,
+    hyprland: h,
 } = options
 
 const {
@@ -112,6 +113,9 @@ export default [
         ),
     ),
     Page("General", icons.ui.settings,
+        Group("Hyprland",
+            Row({ opt: h.gapsWhenOnly, title: "Gaps When Only" }),
+        ),
         Group("Applauncher",
             Row({ opt: al.iconSize, title: "Icon Size" }),
             Row({ opt: al.width, title: "Width" }),


### PR DESCRIPTION
Align hyprland and ags gaps configurations. Enable toggling gaps for windows that are the only window in a workspaces. Default to leaving gaps on.