### PR TITLE
feat(wayland): adopt Universal Wayland Session Manager

### DIFF
--- a/bin/rofi/appmenu
+++ b/bin/rofi/appmenu
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 rofi -show drun \
-     -modi drun,run \
+     -modi drun \
      -show-icons \
-     -theme theme/appmenu.rasi
+     -theme theme/appmenu.rasi \
+     -run-command "uwsm app -- {cmd}"

--- a/hosts/thelio/default.nix
+++ b/hosts/thelio/default.nix
@@ -27,6 +27,10 @@
     services = {
       ssh.enable = true;
       docker.enable = true;
+      dbus = {
+        enable = true;
+        implementation = "broker";
+      };
     };
     theme = {
       active = "catppuccin";

--- a/modules/system/desktop/default.nix
+++ b/modules/system/desktop/default.nix
@@ -1,9 +1,7 @@
 {
   config,
-  options,
   lib,
   pkgs,
-  inputs,
   ...
 }:
 with lib;

--- a/modules/system/desktop/hyprland.nix
+++ b/modules/system/desktop/hyprland.nix
@@ -114,11 +114,8 @@ in {
       upower.enable = true;
       accounts-daemon.enable = true;
       gnome = {
-        # evolution-data-server.enable = true;
         glib-networking.enable = true;
         gnome-keyring.enable = true;
-        # gnome-online-accounts.enable = true;
-        at-spi2-core.enable = true;
       };
     };
 

--- a/modules/system/desktop/hyprland.nix
+++ b/modules/system/desktop/hyprland.nix
@@ -86,7 +86,7 @@ in {
 
       # Gnome stuff
       loupe
-      adwaita-icon-theme
+      # adwaita-icon-theme
       nautilus
       baobab
       # gnome-calendar

--- a/modules/system/desktop/hyprland.nix
+++ b/modules/system/desktop/hyprland.nix
@@ -23,6 +23,9 @@ in {
     # Enable Hyprland
     programs.hyprland = {
       enable = true;
+
+      xwayland.enable = false;
+      withUWSM = true;
       package = inputs.hyprland.packages.${pkgs.system}.hyprland;
       portalPackage = inputs.hyprland.packages."${pkgs.system}".xdg-desktop-portal-hyprland;
     };

--- a/modules/system/desktop/hyprland.nix
+++ b/modules/system/desktop/hyprland.nix
@@ -102,12 +102,6 @@ in {
     ];
 
     services = {
-      redshift.enable = true;
-
-      # xserver = {
-      #   enable = true;
-      # };
-
       displayManager = {
         defaultSession = "hyprland";
       };

--- a/modules/system/security.nix
+++ b/modules/system/security.nix
@@ -122,7 +122,6 @@ in {
       # Setup the Gnome Keyring
       services.gnome.gnome-keyring.enable = true;
       programs.seahorse.enable = true;
-      security.pam.services.keybase.enableGnomeKeyring = true;
 
       # Setup basic log rotation
       services.logrotate.enable = true;
@@ -148,7 +147,7 @@ in {
 
       user.packages = with pkgs; [
         # Setup Keybase for use of storing sensitive credentials
-        kbfs
+        # kbfs
         openssl
         # Security scanning tools
         # Disable until grype can actually build in nixos
@@ -174,7 +173,10 @@ in {
         '')
         nix-tree
       ];
-      services.keybase.enable = true;
+
+      # Enable Keybase
+      # services.keybase.enable = true;
+      # security.pam.services.keybase.enableGnomeKeyring = true;
 
       #
       # Systemd Hardening
@@ -408,35 +410,35 @@ in {
     # This produces a package called "sensitive" that can be ran at anytime to sync
     # credentials from the sensitive repo
 
-    (mkIf (cfg.copySensitive != {})
-      (let
-        sensitive = pkgs.writeScriptBin "sensitive" ''
-          #!/usr/bin/env bash
-          echo "Checking if sensitive repo is setup"
-          if [[ ! -d /etc/sensitive ]]; then
-            echo "[sensitive] cloning sensitive config from keybase"
-            ${pkgs.git}/bin/git clone keybase://private/jordanfaust/sensitive /etc/sensitive
-            if [[ $? -eq 0 ]]; then
-              echo "[sensitive] clone complete"
-            else
-              echo "[sensitive] clone failed, login to keybase required"
-            fi
-          fi
-          if [[ -d /etc/sensitive ]]; then
-            echo "[sensitive] Copying sensitive credentials"
-            ${concatStringsSep "\n"
-            (mapAttrsToList (name: script: ''
-                echo "[${name}]"
-                ${script}
-              '')
-              cfg.copySensitive)}
-          fi
-        '';
-      in {
-        user.packages = [sensitive];
-        system.userActivationScripts.sensitive = ''
-          [ -z "$NORELOAD" ] && ${sensitive}/bin/sensitive
-        '';
-      }))
+    # (mkIf (cfg.copySensitive != {})
+    #   (let
+    #     sensitive = pkgs.writeScriptBin "sensitive" ''
+    #       #!/usr/bin/env bash
+    #       echo "Checking if sensitive repo is setup"
+    #       if [[ ! -d /etc/sensitive ]]; then
+    #         echo "[sensitive] cloning sensitive config from keybase"
+    #         ${pkgs.git}/bin/git clone keybase://private/jordanfaust/sensitive /etc/sensitive
+    #         if [[ $? -eq 0 ]]; then
+    #           echo "[sensitive] clone complete"
+    #         else
+    #           echo "[sensitive] clone failed, login to keybase required"
+    #         fi
+    #       fi
+    #       if [[ -d /etc/sensitive ]]; then
+    #         echo "[sensitive] Copying sensitive credentials"
+    #         ${concatStringsSep "\n"
+    #         (mapAttrsToList (name: script: ''
+    #             echo "[${name}]"
+    #             ${script}
+    #           '')
+    #           cfg.copySensitive)}
+    #       fi
+    #     '';
+    #   in {
+    #     user.packages = [sensitive];
+    #     system.userActivationScripts.sensitive = ''
+    #       [ -z "$NORELOAD" ] && ${sensitive}/bin/sensitive
+    #     '';
+    #   }))
   ];
 }

--- a/modules/system/services/dbus.nix
+++ b/modules/system/services/dbus.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib;
+with lib.my; let
+  cfg = config.modules.services.dbus;
+in {
+  options.modules.services.dbus = {
+    enable = mkOpt types.bool true;
+    apparmor = mkOpt types.str "disabled";
+    implementation = mkOpt types.str "dbus";
+  };
+
+  config = mkIf cfg.enable {
+    services.dbus = {
+      implementation = cfg.implementation;
+      apparmor = cfg.apparmor;
+    };
+  };
+}

--- a/modules/system/shell/zsh.nix
+++ b/modules/system/shell/zsh.nix
@@ -134,9 +134,9 @@ in {
       '';
     };
 
-    system.userActivationScripts.cleanupZgen = ''
-      rm -rf $ZSH_CACHE
-      rm -fv $ZGEN_DIR/init.zsh{,.zwc}
-    '';
+    # system.userActivationScripts.cleanupZgen = ''
+    #   rm -rf $ZSH_CACHE
+    #   rm -fv $ZGEN_DIR/init.zsh{,.zwc}
+    # '';
   };
 }

--- a/modules/system/shell/zsh.nix
+++ b/modules/system/shell/zsh.nix
@@ -133,10 +133,5 @@ in {
         ${cfg.envInit}
       '';
     };
-
-    # system.userActivationScripts.cleanupZgen = ''
-    #   rm -rf $ZSH_CACHE
-    #   rm -fv $ZGEN_DIR/init.zsh{,.zwc}
-    # '';
   };
 }

--- a/modules/user/applications/graphics.nix
+++ b/modules/user/applications/graphics.nix
@@ -2,14 +2,12 @@
   config,
   lib,
   pkgs,
-  inputs,
   osConfig,
   ...
 }:
 with lib;
 with lib.my; let
   cfg = config.modules.applications.graphics;
-  minimal = config.modules.minimal;
 in {
   options.modules.applications.graphics = mkOption {
     description = ''

--- a/modules/user/applications/instant-messangers.nix
+++ b/modules/user/applications/instant-messangers.nix
@@ -2,14 +2,23 @@
   config,
   lib,
   pkgs,
-  inputs,
-  osConfig,
   ...
 }:
 with lib;
 with lib.my; let
   cfg = config.modules.applications.instant-messangers;
   minimal = config.modules.minimal;
+  desktop = pkgs.makeDesktopItem {
+    name = "Slack";
+    desktopName = "Slack";
+    genericName = "Slack Client for Linux";
+    icon = "slack";
+    categories = ["GNOME" "GTK" "Network" "InstantMessaging"];
+    exec = "uwsm app -- ${pkgs.slack}/bin/slack -s %U";
+    mimeTypes = [ "x-scheme-handler/slack" ];
+    startupNotify = true;
+    startupWMClass = "Slack";
+  };
 in {
   options.modules.applications.instant-messangers = mkOption {
     description = ''
@@ -44,9 +53,14 @@ in {
   # Add configured instant messangers if this isn't a minimal install and instant messangers are enabled.
   config = mkIf (!minimal && cfg.enable) {
     home = {
-      packages = with pkgs; [
-        slack
+      packages =[
+        desktop
       ];
+    };
+
+    # Add Slack as a startup application
+    xdg.configFile = {
+      "autostart/slack.desktop".source = "${desktop}/share/applications/Slack.desktop";
     };
   };
 }

--- a/modules/user/applications/kitty.nix
+++ b/modules/user/applications/kitty.nix
@@ -2,12 +2,19 @@
   config,
   lib,
   pkgs,
-  inputs,
   ...
 }:
 with lib;
 with lib.my; let
   cfg = config.modules.applications.kitty;
+  desktop = pkgs.makeDesktopItem {
+    name = "Kitty";
+    desktopName = "Kitty";
+    genericName = "Terminal emulator";
+    icon = "utilities-terminal";
+    exec = "uwsm app -- ${pkgs.kitty}/bin/kitty -e bash -c \"(tmux ls | grep -qEv 'attached|scratch' && tmux at) || tmux\"";
+    categories = ["Development" "System" "Utility"];
+  };
 in {
   options.modules.applications.kitty = mkOption {
     description = ''
@@ -36,22 +43,19 @@ in {
     # '';
 
     home = {
-      packages = with pkgs; [
-        kitty
-        (makeDesktopItem {
-          name = "Kitty";
-          desktopName = "Kitty";
-          genericName = "Kitty terminal";
-          icon = "utilities-terminal";
-          exec = "${kitty}/bin/kitty";
-          categories = ["Development" "System" "Utility"];
-        })
+      packages = [
+        desktop
       ];
 
       sessionVariables = {
         TERMINAL = "kitty";
         TERM = "kitty";
       };
+    };
+
+    # Add Kitty as a startup application
+    xdg.configFile = {
+      "autostart/kitty.desktop".source = "${desktop}/share/applications/Kitty.desktop";
     };
   };
 }

--- a/modules/user/applications/launcher.nix
+++ b/modules/user/applications/launcher.nix
@@ -2,7 +2,6 @@
   config,
   lib,
   pkgs,
-  osConfig,
   ...
 }:
 with lib;

--- a/modules/user/applications/launcher.nix
+++ b/modules/user/applications/launcher.nix
@@ -45,7 +45,7 @@ in {
       packages = with pkgs; [
         (writeScriptBin "rofi" ''
           #!${stdenv.shell}
-          exec ${pkgs.rofi-wayland}/bin/rofi -terminal xst -m -1 "$@"
+          exec ${rofi-wayland}/bin/rofi -terminal ${kitty}/bin/kitty -m -1 "$@"
         '')
       ];
     };

--- a/modules/user/applications/music.nix
+++ b/modules/user/applications/music.nix
@@ -2,14 +2,24 @@
   config,
   lib,
   pkgs,
-  inputs,
-  osConfig,
   ...
 }:
 with lib;
 with lib.my; let
   cfg = config.modules.applications.music;
   minimal = config.modules.minimal;
+  desktop = pkgs.makeDesktopItem {
+    name = "Spotify";
+    desktopName = "spotify";
+    genericName = "Music Player";
+    icon = "spotify-client";
+    categories = ["Audio" "Music" "Player" "AudioVideo"];
+    exec = "uwsm app -- ${pkgs.spotify}/bin/spotify %U";
+    mimeTypes = [ "x-scheme-handler/spotify" ];
+    startupNotify = true;
+    startupWMClass = "spotify";
+    terminal = false;
+  };
 in {
   options.modules.applications.music = mkOption {
     description = ''
@@ -35,12 +45,17 @@ in {
 
   config = mkIf (!minimal && cfg.enable) {
     home = {
-      packages = with pkgs; [
+      packages = [
         # spotify-tui is fine for selecting and playing music, but incomplete. We
         # still occasionally need the official client for more sophisticated
         # search and the "made for you" playlists.
-        spotify
+        desktop
       ];
+    };
+
+    # Add Spotify as a startup application
+    xdg.configFile = {
+      "autostart/spotify.desktop".source = "${desktop}/share/applications/Spotify.desktop";
     };
   };
 }

--- a/modules/user/applications/neovim.nix
+++ b/modules/user/applications/neovim.nix
@@ -12,8 +12,6 @@ with lib.my; let
     desktopName = "Neovim";
     genericName = "Text Editor";
     icon = "nvim";
-    # KITTY_ENABLE_WAYLAND must be set here or integrations with wayland, such as copy/paste, won't work
-    # exec = "";
     exec = "uwsm app -- ${pkgs.kitty}/bin/kitty --title Neovim --class neovim -e nvim %F";
     categories = ["Utility" "TextEditor"];
   };

--- a/modules/user/applications/neovim.nix
+++ b/modules/user/applications/neovim.nix
@@ -2,12 +2,19 @@
   config,
   lib,
   pkgs,
-  inputs,
   ...
 }:
 with lib;
 with lib.my; let
   cfg = config.modules.applications.neovim;
+  desktop = pkgs.makeDesktopItem {
+    name = "Neovim";
+    desktopName = "Neovim";
+    genericName = "Text Editor";
+    icon = "nvim";
+    exec = "uwsm app -- ${pkgs.kitty}/bin/kitty --title Neovim --class neovim -e nvim %F";
+    categories = ["Utility" "TextEditor"];
+  };
 in {
   options.modules.applications.neovim = mkOption {
     description = ''
@@ -59,45 +66,16 @@ in {
         # Code Snippet Image Generator
         codesnap
 
-        (makeDesktopItem {
-          name = "Neovim";
-          desktopName = "Neovim";
-          genericName = "Text Editor";
-          icon = "nvim";
-          # KITTY_ENABLE_WAYLAND must be set here or integrations with wayland, such as copy/paste, won't work
-          exec = "bash -c \"KITTY_ENABLE_WAYLAND=1; ${kitty}/bin/kitty --title Neovim --class neovim -e nvim %F\"";
-          categories = ["Utility" "TextEditor"];
-        })
+        # desktop
+        desktop
       ];
     };
 
     xdg.configFile = {
-      "neovide/config.toml".source = (pkgs.formats.toml {}).generate "config.toml" {
-        #
-        # Monaspace
-        #
-        # font = {
-        #   normal = [
-        #     {
-        #       family = "Monaspace Neon";
-        #       style = "Normal";
-        #     }
-        #   ];
-        #   bold = {
-        #     family = "Monaspace Neon Var";
-        #     style = "ExtraBold";
-        #   };
-        #   italic = {
-        #     family = "Monaspace Radon Var";
-        #     style = "Italic SemiBold";
-        #   };
-        #   bold_italic = {
-        #     family = "Monaspace Radon Var";
-        #     style = "Italic ExtraBold";
-        #   };
-        #   size = 16;
-        # };
+      # Add Neovim as a startup application
+      "autostart/neovim.desktop".source = "${desktop}/share/applications/Neovim.desktop";
 
+      "neovide/config.toml".source = (pkgs.formats.toml {}).generate "config.toml" {
         #
         # MonoLisa
         #
@@ -126,29 +104,6 @@ in {
           };
           size = 16;
         };
-        # font.features = {
-        #   MonoLisa = [ "+ss01" ];
-        # };
-
-        # font = {
-        #   normal = {
-        #     family = "Cascadia Code";
-        #     style = "Medium";
-        #   };
-        #   bold = {
-        #     family = "Cascadia Code";
-        #     style = "Bold";
-        #   };
-        #   italic = {
-        #     family = "Victor Mono";
-        #     style = "Italic SemiBold";
-        #   };
-        #   bold_italic = {
-        #     family = "Victor Mono";
-        #     style = "Bold Italic";
-        #   };
-        #   size = 14;
-        # };
       };
     };
   };

--- a/modules/user/applications/neovim.nix
+++ b/modules/user/applications/neovim.nix
@@ -12,6 +12,8 @@ with lib.my; let
     desktopName = "Neovim";
     genericName = "Text Editor";
     icon = "nvim";
+    # KITTY_ENABLE_WAYLAND must be set here or integrations with wayland, such as copy/paste, won't work
+    # exec = "";
     exec = "uwsm app -- ${pkgs.kitty}/bin/kitty --title Neovim --class neovim -e nvim %F";
     categories = ["Utility" "TextEditor"];
   };

--- a/modules/user/desktop/gtk.nix
+++ b/modules/user/desktop/gtk.nix
@@ -2,16 +2,11 @@
   config,
   lib,
   pkgs,
-  inputs,
-  osConfig,
   ...
 }:
 with lib;
 with lib.my; let
   cfg = config.modules.desktop.gtk;
-  cursor-theme = "Qogir";
-  cursor-package = pkgs.qogir-icon-theme;
-  qtTheme = strings.concatStrings (strings.splitString "-" cfg.qt.name);
 in {
   options.modules.desktop.gtk = mkOption {
     description = ''
@@ -41,7 +36,7 @@ in {
                 default = "Adwaita";
                 defaultText = literalExpression ''"Adwaita"'';
                 example = literalExpression ''"Yaru"'';
-                description = "Name of the cursor theme within the package.";
+                description = "Name of the theme within the package.";
               };
 
               #
@@ -54,7 +49,7 @@ in {
                   defaultText = literalExpression "null";
                   example = literalExpression "pkgs.yaru-theme";
                   description = ''
-                    Package providing the curosr theme. This package will be installed to your profile.
+                    Package providing the cursor theme. This package will be installed to your profile.
                     If `null` then the cursor theme is assumed to already be available.
                   '';
                 };

--- a/modules/user/desktop/gtk.nix
+++ b/modules/user/desktop/gtk.nix
@@ -72,6 +72,42 @@ in {
               };
 
               #
+              # Font Configuration
+              #
+              font = {
+                name = mkOption {
+                  type = with types; str;
+                  default = "MonoLisa Variable Regular";
+                  defaultText = literalExpression ''"MonoLisa Variable Regular"'';
+                  example = literalExpression ''"Yaru"'';
+                  description = "Name of the font to use for GTK applications.";
+                };
+              };
+
+              #
+              # Icon Theme Configuration
+              #
+              icon = {
+                package = mkOption {
+                  type = with types; nullOr package;
+                  default = "Papirus";
+                  defaultText = literalExpression ''"Papirus"'';
+                  example = literalExpression "pkgs.yaru-theme";
+                  description = ''
+                    Package providing the icon theme. This package will be installed to your profile.
+                    If `null` then the cursor theme is assumed to already be available.
+                  '';
+                };
+                name = mkOption {
+                  type = with types; str;
+                  default = "Papirus";
+                  defaultText = literalExpression ''"Papirus"'';
+                  example = literalExpression ''"Yaru"'';
+                  description = "Name of the icon theme within the package.";
+                };
+              };
+
+              #
               # QT Theme Configuration
               #
               qt = {
@@ -146,7 +182,7 @@ in {
 
     gtk = {
       enable = cfg.enable;
-      font.name = "Cascadia Code Regular";
+      font.name = cfg.font.name;
       theme = {
         name = cfg.name;
         package = cfg.package;
@@ -158,7 +194,8 @@ in {
         size = cfg.cursor.size;
       };
 
-      iconTheme.name = "MoreWaita";
+      iconTheme.name = cfg.icon.name;
+      iconTheme.package = cfg.icon.package;
 
       gtk3.extraConfig = {
         "gtk-application-prefer-dark-theme" = "1";

--- a/modules/user/desktop/hyprland/default.nix
+++ b/modules/user/desktop/hyprland/default.nix
@@ -8,6 +8,7 @@
 with lib;
 with lib.my; let
   cfg = config.modules.desktop.hyprland;
+
   hyprland = inputs.hyprland.packages.${pkgs.system}.hyprland;
 
   yt = pkgs.writeShellScript "yt" ''
@@ -18,6 +19,8 @@ with lib.my; let
   playerctl = "${pkgs.playerctl}/bin/playerctl";
   brightnessctl = "${pkgs.brightnessctl}/bin/brightnessctl";
   pactl = "${pkgs.pulseaudio}/bin/pactl";
+
+  gtkTheme = config.modules.desktop.gtk.name;
 
   cursor = {
     name = config.modules.desktop.gtk.cursor.name;
@@ -69,6 +72,19 @@ in {
           "org.freedesktop.impl.portal.FileChooser" = "kde";
         };
       };
+
+      # Set relevant environment variables outside of the hyprland.conf directory.
+      # See https://wiki.hyprland.org/Configuring/Environment-variables/
+      "uwsm/env" = {
+
+        text = ''
+          #!/usr/bin/env bash
+          export UWSM_FINALIZE_VARNAMES="''${UWSM_FINALIZE_VARNAMES} WAYLAND_DISPLAY"
+          export GTK_THEME=${gtkTheme}
+          export XCURSOR_THEME=${builtins.toString cursor.name}
+          export XCURSOR_SIZE=${builtins.toString cursor.size}
+        '';
+      };
     };
 
     wayland.windowManager.hyprland = {
@@ -85,7 +101,7 @@ in {
           "uwsm app -- ${pkgs.hyprpanel}/bin/hyprpanel"
           "uwsm app -- wl-paste --type text --watch cliphist store"
           "uwsm app -- wl-paste --type image --watch cliphist store"
-          # "hyprctl setcursor ${cursor.name} ${builtins.toString cursor.size}"
+          "hyprctl setcursor ${cursor.name} ${builtins.toString cursor.size}"
         ];
 
         monitor = [

--- a/modules/user/desktop/hyprland/default.nix
+++ b/modules/user/desktop/hyprland/default.nix
@@ -79,7 +79,7 @@ in {
 
       settings = {
         exec-once = [
-          "dbus-update-activation-environment --systemd --all"
+          # "dbus-update-activation-environment --systemd --all"
           "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME"
           "${pkgs.swww}/bin/swww init"
           "${pkgs.hyprpanel}/bin/hyprpanel"

--- a/modules/user/desktop/hyprland/default.nix
+++ b/modules/user/desktop/hyprland/default.nix
@@ -82,7 +82,7 @@ in {
           export UWSM_FINALIZE_VARNAMES="''${UWSM_FINALIZE_VARNAMES} WAYLAND_DISPLAY"
           export GTK_THEME=${gtkTheme}
           export XCURSOR_THEME=${builtins.toString cursor.name}
-          export XCURSOR_SIZE=24
+          export XCURSOR_SIZE=${builtins.toString cursor.size}
         '';
       };
 
@@ -109,7 +109,7 @@ in {
           "uwsm app -- ${pkgs.hyprpanel}/bin/hyprpanel"
           "uwsm app -- wl-paste --type text --watch cliphist store"
           "uwsm app -- wl-paste --type image --watch cliphist store"
-          "hyprctl setcursor ${cursor.name} ${builtins.toString cursor.size}"
+          "uwsm app -- hyprctl setcursor ${cursor.name} ${builtins.toString cursor.size}"
         ];
 
         monitor = [
@@ -182,6 +182,7 @@ in {
           (fregex "xdg-desktop-portal-gnome")
           (fregex "transmission-gtk")
           (fregex "com.github.Aylur.ags")
+          "workspace 2 silent, class:^(firefox)$"
           "workspace 3 silent, title:^(Spotify Premium)$"
           "workspace 3 silent, class:^(Slack)$"
           "workspace 3 silent, initialTitle:^(Slack)$"
@@ -210,6 +211,13 @@ in {
           (pin "as_toolbar" "zoom")
           # Inhibit Screen Locking/Sleeping during video calls/watching videos
           (inhibitfocus "Zoom Meeting")
+
+          # Autostart workspace placement
+          "workspace 2 silent, class:neovim"
+          "workspace 2 silent, class:firefox"
+          "workspace 3 silent, class:Slack"
+          "workspace 3 silent, class:spotify"
+          "workspace 4 silent, class:chromium-browser"
         ];
 
         bind = let

--- a/modules/user/desktop/hyprland/default.nix
+++ b/modules/user/desktop/hyprland/default.nix
@@ -9,7 +9,6 @@ with lib;
 with lib.my; let
   cfg = config.modules.desktop.hyprland;
   hyprland = inputs.hyprland.packages.${pkgs.system}.hyprland;
-  plugins = inputs.hyprland-plugins.packages.${pkgs.system};
 
   yt = pkgs.writeShellScript "yt" ''
     notify-send "Opening video" "$(wl-paste)"
@@ -75,17 +74,18 @@ in {
     wayland.windowManager.hyprland = {
       enable = true;
       package = hyprland;
-      systemd.enable = true;
+      systemd.enable = false;
+      xwayland.enable = false;
 
       settings = {
         exec-once = [
           # "dbus-update-activation-environment --systemd --all"
-          "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME"
-          "${pkgs.swww}/bin/swww init"
-          "${pkgs.hyprpanel}/bin/hyprpanel"
-          "hyprctl setcursor ${cursor.name} ${builtins.toString cursor.size}"
-          "wl-paste --type text --watch cliphist store"
-          "wl-paste --type image --watch cliphist store"
+          # "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME"
+          "uwsm app -- ${pkgs.swww}/bin/swww init"
+          "uwsm app -- ${pkgs.hyprpanel}/bin/hyprpanel"
+          "uwsm app -- wl-paste --type text --watch cliphist store"
+          "uwsm app -- wl-paste --type image --watch cliphist store"
+          # "hyprctl setcursor ${cursor.name} ${builtins.toString cursor.size}"
         ];
 
         monitor = [

--- a/modules/user/desktop/hyprland/default.nix
+++ b/modules/user/desktop/hyprland/default.nix
@@ -73,16 +73,26 @@ in {
         };
       };
 
-      # Set relevant environment variables outside of the hyprland.conf directory.
+      # Set relevant environment variables outside of the hyprland.conf directory for
+      # theming, xcursor, nvidia and general toolkit variables.
       # See https://wiki.hyprland.org/Configuring/Environment-variables/
       "uwsm/env" = {
-
         text = ''
           #!/usr/bin/env bash
           export UWSM_FINALIZE_VARNAMES="''${UWSM_FINALIZE_VARNAMES} WAYLAND_DISPLAY"
           export GTK_THEME=${gtkTheme}
           export XCURSOR_THEME=${builtins.toString cursor.name}
-          export XCURSOR_SIZE=${builtins.toString cursor.size}
+          export XCURSOR_SIZE=24
+        '';
+      };
+
+      # Set relevant environment variables for hyprland and aquamarine
+      # See https://wiki.hyprland.org/Configuring/Environment-variables/
+      "uwsm/env-hyprland" = {
+        text = ''
+          #!/usr/bin/env bash
+          export HYPRCURSOR_THEME=${builtins.toString cursor.name}
+          export HYPRCURSOR_SIZE=${builtins.toString cursor.size}
         '';
       };
     };
@@ -95,9 +105,7 @@ in {
 
       settings = {
         exec-once = [
-          # "dbus-update-activation-environment --systemd --all"
-          # "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME"
-          "uwsm app -- ${pkgs.swww}/bin/swww init"
+          "uwsm app -- ${pkgs.swww}/bin/swww-daemon"
           "uwsm app -- ${pkgs.hyprpanel}/bin/hyprpanel"
           "uwsm app -- wl-paste --type text --watch cliphist store"
           "uwsm app -- wl-paste --type image --watch cliphist store"

--- a/modules/user/desktop/hyprland/hypridle.nix
+++ b/modules/user/desktop/hyprland/hypridle.nix
@@ -22,7 +22,7 @@ in {
           # Lock Screen Timeout
           {
             timeout = 900;
-            on-timeout = "${lib.getExe inputs.hyprlock.packages.${system}.default}";
+            on-timeout = "uwsm app -- ${lib.getExe inputs.hyprlock.packages.${system}.default}";
             on-resume = "${lib.getExe pkgs.libnotify} Unlocked!";
           }
           # Screen Off

--- a/modules/user/desktop/hyprland/hypridle.nix
+++ b/modules/user/desktop/hyprland/hypridle.nix
@@ -39,5 +39,9 @@ in {
         ];
       };
     };
+
+    # No loger needed after https://github.com/NixOS/nixpkgs/pull/355416/files
+    systemd.user.services.hypridle.Install.WantedBy = [ "wayland-session@Hyprland.target" ];
+    systemd.user.services.hypridle.Unit.After = [ "wayland-session@Hyprland.target" ];
   };
 }

--- a/modules/user/desktop/hyprland/hyprlock.nix
+++ b/modules/user/desktop/hyprland/hyprlock.nix
@@ -6,7 +6,6 @@
 let
   cfg = config.modules.desktop.hyprland;
 in {
-  # imports = [inputs.hyprlock.homeManagerModules.default];
   options = {};
 
   config = lib.mkIf (cfg.enable) {
@@ -66,7 +65,7 @@ in {
             text_align = "center";
             color = "rgb(ded8d7)";
             font_size = 84;
-            font_family = "Cascadia Code Normal";
+            font_family = "MonoLisa Variable Regular";
             position = "0, 100";
             halign = "center";
             valign = "center";
@@ -77,7 +76,7 @@ in {
             text = "Hey <span text_transform=\"capitalize\" size=\"larger\">$USER</span>";
             color = "rgb(ded8d7)";
             font_size = 20;
-            font_family = "Cascadia Code Normal";
+            font_family = "MonoLisa Variable Regular";
             position = "0, 0";
             halign = "center";
             valign = "center";
@@ -88,7 +87,7 @@ in {
             text = "Type to unlock!";
             color = "rgb(ded8d7)";
             font_size = 16;
-            font_family = "Cascadia Code Normal";
+            font_family = "MonoLisa Variable Regular";
             position = "0, 32";
             halign = "center";
             valign = "bottom";

--- a/modules/user/themes/catppuccin/catppuccin.nix
+++ b/modules/user/themes/catppuccin/catppuccin.nix
@@ -9,7 +9,6 @@
 with lib;
 with lib.my; let
   cfg = config.modules.themes.catppuccin;
-  gtk-theme = "Catppuccin-Macchiato-Compact-Rosewater-Dark";
 in {
   options.modules.themes.catppuccin = mkOption {
     description = ''
@@ -38,9 +37,6 @@ in {
   config = lib.mkIf (cfg.enable) {
     home = {
       packages = with pkgs; [
-        paper-icon-theme # for rofi
-        papirus-icon-theme # dunst
-        adwaita-icon-theme
         # TODO replace pamixer with amixer
         # misc
         gpick
@@ -52,9 +48,8 @@ in {
         # Fix broken nerd fonts
         nerdfix
 
-        adw-gtk3
+        # adw-gtk3
         font-awesome
-        morewaita-icon-theme
         cantarell-fonts
 
         (catppuccin-kde.override {
@@ -76,7 +71,7 @@ in {
         inputs.private-fonts.packages.${system}.monolisa-variable
         # monaspace
         # General Sans Fonts
-        open-sans
+        # open-sans
 
         siji
         nerd-fonts.caskaydia-cove
@@ -126,12 +121,22 @@ in {
 
     modules.desktop.gtk = {
       enable = true;
-      name = gtk-theme;
-      package = pkgs.stable.catppuccin-gtk.override {
-        accents = ["rosewater"];
+      name = "Catppuccin-GTK-Red-Dark-Compact-Macchiato";
+      package = pkgs.magnetic-catppuccin-gtk.override {
+        accent = ["red"];
         size = "compact";
-        tweaks = ["rimless" "black"];
-        variant = "macchiato";
+        tweaks = ["macchiato"];
+        shade = "dark";
+      };
+
+      font.name = "MonoLisa Variable Regular";
+
+      icon = {
+        name = "Papirus";
+        package = pkgs.catppuccin-papirus-folders.override {
+          accent = "red";
+          flavor = "macchiato";
+        };
       };
 
       cursor = {
@@ -143,7 +148,7 @@ in {
       qt = {
         style = "kvantum";
         platformTheme = "qt5ct";
-        name = "Catppuccin-Macchiato-Rosewater";
+        name = "catppuccin-macchiato-rosewater";
         package = pkgs.catppuccin-kvantum.override {
           accent = "rosewater";
           variant = "macchiato";

--- a/modules/user/themes/catppuccin/catppuccin.nix
+++ b/modules/user/themes/catppuccin/catppuccin.nix
@@ -10,8 +10,6 @@ with lib;
 with lib.my; let
   cfg = config.modules.themes.catppuccin;
   gtk-theme = "Catppuccin-Macchiato-Compact-Rosewater-Dark";
-  cursor-theme = "Qogir";
-  cursor-package = pkgs.qogir-icon-theme;
 in {
   options.modules.themes.catppuccin = mkOption {
     description = ''

--- a/modules/user/themes/catppuccin/catppuccin.nix
+++ b/modules/user/themes/catppuccin/catppuccin.nix
@@ -137,7 +137,7 @@ in {
       cursor = {
         name = "catppuccin-macchiato-red-cursors";
         package = pkgs.catppuccin-cursors.macchiatoRed;
-        size = 36;
+        size = 32;
       };
 
       qt = {

--- a/modules/user/themes/catppuccin/config/hyprpanel/config.json
+++ b/modules/user/themes/catppuccin/config/hyprpanel/config.json
@@ -62,7 +62,7 @@
 	"bar.windowtitle.title_map": [
 		[
 			"kitty",
-			"󰄛",
+			"",
 			"Kitty Terminal"
 		],
 		[
@@ -135,14 +135,19 @@
 	"menus.dashboard.directories.enabled": true,
 	"menus.dashboard.powermenu.avatar.image": "/home/jordan/.face",
 	"menus.dashboard.powermenu.confirmation": false,
+	"menus.dashboard.powermenu.logout": "loginctrl terminate-user ''",
 	"menus.dashboard.shortcuts.enabled": true,
-	"menus.dashboard.shortcuts.left.shortcut1.command": "firefox",
+	"menus.dashboard.shortcuts.left.shortcut1.command": "uwsm app -- firefox.desktop",
 	"menus.dashboard.shortcuts.left.shortcut1.icon": "󰈹",
 	"menus.dashboard.shortcuts.left.shortcut1.tooltip": "Firefox",
-	"menus.dashboard.shortcuts.left.shortcut3.command": "slack",
+	"menus.dashboard.shortcuts.left.shortcut2.command": "uwsm app -- Spotify.desktop",
+	"menus.dashboard.shortcuts.left.shortcut2.icon": "󰓇",
+	"menus.dashboard.shortcuts.left.shortcut2.tooltip": "Spotify",
+	"menus.dashboard.shortcuts.left.shortcut3.command": "uwsm app -- Slack.desktop",
 	"menus.dashboard.shortcuts.left.shortcut3.icon": "󰒱",
 	"menus.dashboard.shortcuts.left.shortcut3.tooltip": "Slack",
-	"menus.dashboard.shortcuts.left.shortcut4.command": "$DOTFILES_BIN/rofi/appmenu",
+	"menus.dashboard.shortcuts.left.shortcut4.command": "uwsm app -- bash -c '$DOTFILES_BIN/rofi/appmenu'",
+	"menus.dashboard.shortcuts.right.shortcut3.command": "uwsm app -- bash -c 'grim -g \"$(slurp -d)\" - | wl-copy'",
 	"menus.dashboard.stats.enabled": true,
 	"menus.media.displayTime": true,
 	"menus.power.confirmation": false,


### PR DESCRIPTION
Switch to Universal Wayland Session Manager as a recommended way to
start Hyprland session on systemd distros. This provides robust session
management including environment, XDG autostart support, bi-directional
binding with login session, and clean shutdown.

Some fundamentals are changing as part of this:

* DBus implementation changed to 'dbus-broker'
* Migration of Hyprland exec-once steps to systemd as much as possible
* Automate startup via XDG autostart (Slack, Firefox, Neovim, Kitty, etc)